### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "ids",
     "name_pretty": "Cloud IDS",
     "product_documentation": "https://cloud.google.com/intrusion-detection-system/",
-    "client_documentation": "https://googleapis.dev/python/ids/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/ids/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ threat detection.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-ids.svg
    :target: https://pypi.org/project/google-cloud-ids/
 .. _Cloud IDS: https://cloud.google.com/intrusion-detection-system
-.. _Client Library Documentation: https://googleapis.dev/python/ids/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/ids/latest
 .. _Product Documentation:  https://cloud.google.com/intrusion-detection-system/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.